### PR TITLE
Read Appdata From Installed Flatpak Apps

### DIFF
--- a/io.elementary.feedback.yml
+++ b/io.elementary.feedback.yml
@@ -1,9 +1,13 @@
 app-id: io.elementary.feedback
 runtime: io.elementary.Platform
-runtime-version: '0.1.0'
+runtime-version: daily
 sdk: io.elementary.Sdk
 command: io.elementary.feedback
 finish-args:
+  # for host metadata, '--filesystem=/usr/share/metainfo:ro' won't work.
+  - '--filesystem=host:ro'
+  - '--filesystem=/var/lib/flatpak:ro' # for flatpak metadata
+
   - '--share=ipc'
   - '--share=network'
   - '--socket=fallback-x11'
@@ -12,8 +16,8 @@ finish-args:
   # needed for perfers-color-scheme
   - '--system-talk-name=org.freedesktop.Accounts'
 
-  # needed to read app metadata
-  - '--filesystem=host:ro'
+  # we need to add flatpak export to XDG_DATA_DIRS for icons
+  - '--env=XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/share:/var/lib/flatpak/exports/share'
 
   - '--metadata=X-DConf=migrate-path=/io/elementary/feedback/'
 cleanup:
@@ -28,6 +32,8 @@ cleanup:
 modules:
   - name: appstream
     buildsystem: meson
+    cleanup:
+      - /bin
     config-opts:
       - '-Dvapi=true'
       - '-Dapidocs=false'
@@ -40,8 +46,9 @@ modules:
       - name: xapian
         cleanup:
           - '/lib/cmake'
-          - '/share/alocal'
+          - '/share/aclocal'
           - '/share/doc'
+          - '/bin'
         sources:
           - type: archive
             url: https://oligarchy.co.uk/xapian/1.4.17/xapian-core-1.4.17.tar.xz
@@ -59,11 +66,15 @@ modules:
             url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
             md5: 12e517cac2b57a0121cda351570f1e63
       - name: xmlto
+        cleanup:
+          - '/bin'
         sources:
           - type: archive
             url: https://releases.pagure.org/xmlto/xmlto-0.0.28.tar.bz2
             md5: 93bab48d446c826399d130d959fe676f
       - name: lmdb
+        cleanup:
+          - '/bin'
         no-autogen: true
         make-install-args:
           - 'prefix=/app'

--- a/io.elementary.feedback.yml
+++ b/io.elementary.feedback.yml
@@ -16,9 +16,6 @@ finish-args:
   # needed for perfers-color-scheme
   - '--system-talk-name=org.freedesktop.Accounts'
 
-  # we need to add flatpak export to XDG_DATA_DIRS for icons
-  - '--env=XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/share:/var/lib/flatpak/exports/share'
-
   - '--metadata=X-DConf=migrate-path=/io/elementary/feedback/'
 cleanup:
   - '/include'

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -20,6 +20,7 @@
 
 public class Feedback.Application : Gtk.Application {
     public static GLib.Settings settings;
+    public static bool sandboxed;
     private MainWindow main_window;
 
     public Application () {
@@ -31,12 +32,17 @@ public class Feedback.Application : Gtk.Application {
 
     static construct {
         settings = new Settings ("io.elementary.feedback");
+        sandboxed = FileUtils.test ("/.flatpak-info", FileTest.EXISTS);
     }
 
     protected override void activate () {
         if (get_windows ().length () > 0) {
             get_windows ().data.present ();
             return;
+        }
+
+        if (sandboxed) {
+            Gtk.IconTheme.get_default ().prepend_search_path ("/var/lib/flatpak/exports/share/icons");
         }
 
         main_window = new MainWindow (this);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -75,13 +75,21 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
         listbox.set_sort_func (sort_function);
 
         var appstream_pool = new AppStream.Pool ();
+        appstream_pool.set_flags (AppStream.PoolFlags.READ_COLLECTION);
+        appstream_pool.clear_metadata_locations ();
         try {
             bool sandboxed = FileUtils.test ("/.flatpak-info", FileTest.EXISTS);
 
             if (sandboxed) {
                 appstream_pool.add_metadata_location ("/run/host/usr/share/metainfo/");
             } else {
-                appstream_pool.set_flags (AppStream.PoolFlags.READ_METAINFO);
+                appstream_pool.add_metadata_location ("/usr/share/metainfo/");
+            }
+
+            // flatpak's appstream files exists only inside they sandbox
+            var appdata_dir = "/var/lib/flatpak/app/%s/current/active/files/share/appdata";
+            foreach (var app in app_entries) {
+                appstream_pool.add_metadata_location (appdata_dir.printf (app));
             }
 
             appstream_pool.load ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -75,13 +75,10 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
         listbox.set_sort_func (sort_function);
 
         var appstream_pool = new AppStream.Pool ();
-        appstream_pool.set_flags (AppStream.PoolFlags.READ_COLLECTION);
         appstream_pool.clear_metadata_locations ();
         try {
             if (Application.sandboxed) {
                 appstream_pool.add_metadata_location ("/run/host/usr/share/metainfo/");
-            } else {
-                appstream_pool.add_metadata_location ("/usr/share/metainfo/");
             }
 
             // flatpak's appstream files exists only inside they sandbox

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -78,9 +78,7 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
         appstream_pool.set_flags (AppStream.PoolFlags.READ_COLLECTION);
         appstream_pool.clear_metadata_locations ();
         try {
-            bool sandboxed = FileUtils.test ("/.flatpak-info", FileTest.EXISTS);
-
-            if (sandboxed) {
+            if (Application.sandboxed) {
                 appstream_pool.add_metadata_location ("/run/host/usr/share/metainfo/");
             } else {
                 appstream_pool.add_metadata_location ("/usr/share/metainfo/");

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -274,7 +274,7 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
          "org.pantheon.mail",
          "io.elementary.music",
          "io.elementary.photos",
-         "io.elementary.screenshot-tool",
+         "io.elementary.screenshot",
          "io.elementary.terminal",
          "io.elementary.videos"
     };


### PR DESCRIPTION
Since some default apps are now using flatpak, they stopped to appear here. This PR fix that. It still doesn't fix epiphany not showing though.

also, this update the screenshot RDNN, change the flatpak runtime to daily, and remove some useless binaries from the sandbox.