### PR TITLE
Add missing entries for Odin

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -269,6 +269,7 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
          "io.elementary.files",
          "io.elementary.mail",
          "io.elementary.music",
+         "io.elementary.onboarding",
          "io.elementary.photos",
          "io.elementary.screenshot",
          "io.elementary.tasks",
@@ -285,6 +286,10 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
         SystemEntry () {
             name = _("Applications Menu"),
             issues_url = "https://github.com/elementary/applications-menu/issues/new/choose"
+        },
+        SystemEntry () {
+            name = _("Dock"),
+            issues_url = "https://github.com/elementary/dock/issues/new/choose"
         },
         SystemEntry () {
             name = _("Lock or Login Screen"),

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -269,7 +269,6 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
          "io.elementary.files",
          "io.elementary.mail",
          "io.elementary.music",
-         "io.elementary.onboarding",
          "io.elementary.photos",
          "io.elementary.screenshot",
          "io.elementary.tasks",
@@ -286,6 +285,10 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
         SystemEntry () {
             name = _("Applications Menu"),
             issues_url = "https://github.com/elementary/applications-menu/issues/new/choose"
+        },
+        SystemEntry () {
+            name = _("Captive Network Assistant"),
+            issues_url = "https://github.com/elementary/capnet-assist/issues/new/choose"
         },
         SystemEntry () {
             name = _("Dock"),
@@ -306,6 +309,10 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
         SystemEntry () {
             name = _("Notifications"),
             issues_url = "https://github.com/elementary/notifications/issues/new/choose"
+        },
+        SystemEntry () {
+            name = _("Welcome & Onboarding"),
+            issues_url = "https://github.com/elementary/onboarding/issues/new/choose"
         },
         SystemEntry () {
             name = _("Panel"),

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -306,7 +306,11 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
         SystemEntry () {
             name = _("Notifications"),
             issues_url = "https://github.com/elementary/notifications/issues/new/choose"
-        }
+        },
+        SystemEntry () {
+            name = _("Panel"),
+            issues_url = "https://github.com/elementary/wingpanel/issues/new/choose"
+        },
     };
 
     private struct SwitchboardEntry {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -419,6 +419,10 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
 
     static WingpanelEntry[] wingpanel_entries = {
         WingpanelEntry () {
+            icon = "preferences-desktop-accessibility-symbolic",
+            id="io.elementary.wingpanel.a11y"
+        },
+        WingpanelEntry () {
             icon = "bluetooth-active-symbolic",
             id="io.elementary.wingpanel.bluetooth"
         },

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -394,6 +394,10 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
         SwitchboardEntry () {
             icon = "system-users",
             id = "io.elementary.switchboard.useraccounts"
+        },
+        SwitchboardEntry () {
+            icon = "input-tablet",
+            id = "io.elementary.switchboard.wacom"
         }
     };
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -310,7 +310,7 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
         SystemEntry () {
             name = _("Panel"),
             issues_url = "https://github.com/elementary/wingpanel/issues/new/choose"
-        },
+        }
     };
 
     private struct SwitchboardEntry {


### PR DESCRIPTION
Fixes #8 
Fixes #44 
Fixes #43

Probably should double check for any other missing entries before merging

- [x] a11y indicator
- [x] onboarding under Desktop