### PR TITLE
MainWindow: Get system entries from appstream

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -122,10 +122,14 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
                 });
             }
 
-            foreach (var entry in system_entries) {
-                var repo_row = new RepoRow (entry.name, new ThemedIcon ("application-default-icon"), Category.SYSTEM, entry.issues_url);
-                listbox.add (repo_row);
-            }
+            // FIXME: Dock should ship appdata
+            var dock_row = new RepoRow (
+                _("Dock"),
+                new ThemedIcon ("application-default-icon"),
+                Category.SYSTEM,
+                "https://github.com/elementary/dock/issues/new/choose"
+            );
+            listbox.add (dock_row);
 
             appstream_pool.get_components ().foreach ((component) => {
                 component.get_compulsory_for_desktops ().foreach ((desktop) => {
@@ -309,26 +313,6 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
          "io.elementary.videos"
     };
 
-    private struct SystemEntry {
-        string name;
-        string issues_url;
-    }
-
-    static SystemEntry[] system_entries = {
-        SystemEntry () {
-            name = _("Applications Menu"),
-            issues_url = "https://github.com/elementary/applications-menu/issues/new/choose"
-        },
-        SystemEntry () {
-            name = _("Captive Network Assistant"),
-            issues_url = "https://github.com/elementary/capnet-assist/issues/new/choose"
-        },
-        SystemEntry () {
-            name = _("Dock"),
-            issues_url = "https://github.com/elementary/dock/issues/new/choose"
-        }
-    };
-
     private struct SwitchboardEntry {
         string icon;
         string id;
@@ -430,6 +414,10 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
         WingpanelEntry () {
             icon = "preferences-desktop-accessibility-symbolic",
             id="io.elementary.wingpanel.a11y"
+        },
+        WingpanelEntry () {
+            icon = "preferences-system-search-symbolic",
+            id="io.elementary.wingpanel.applications-menu"
         },
         WingpanelEntry () {
             icon = "bluetooth-active-symbolic",

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -105,9 +105,24 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
             }
 
             foreach (var entry in system_entries) {
-                var repo_row = new RepoRow (entry.name, null, Category.SYSTEM, entry.issues_url);
+                var repo_row = new RepoRow (entry.name, new ThemedIcon ("application-default-icon"), Category.SYSTEM, entry.issues_url);
                 listbox.add (repo_row);
             }
+
+            appstream_pool.get_components ().foreach ((component) => {
+                component.get_compulsory_for_desktops ().foreach ((desktop) => {
+                    if (desktop == Environment.get_variable ("XDG_CURRENT_DESKTOP")) {
+                        var repo_row = new RepoRow (
+                            component.name,
+                            icon_from_appstream_component (component),
+                            Category.SYSTEM,
+                            component.get_url (AppStream.UrlKind.BUGTRACKER)
+                        );
+
+                        listbox.add (repo_row);
+                    }
+                });
+            });
 
             foreach (var entry in switchboard_entries) {
                 appstream_pool.get_components_by_id (entry.id).foreach ((component) => {
@@ -293,30 +308,6 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
         SystemEntry () {
             name = _("Dock"),
             issues_url = "https://github.com/elementary/dock/issues/new/choose"
-        },
-        SystemEntry () {
-            name = _("Lock or Login Screen"),
-            issues_url = "https://github.com/elementary/greeter/issues/new/choose"
-        },
-        SystemEntry () {
-            name = _("Look & Feel"),
-            issues_url = "https://github.com/elementary/stylesheet/issues/new/choose"
-        },
-        SystemEntry () {
-            name = _("Multitasking or Window Management"),
-            issues_url = "https://github.com/elementary/gala/issues/new/choose"
-        },
-        SystemEntry () {
-            name = _("Notifications"),
-            issues_url = "https://github.com/elementary/notifications/issues/new/choose"
-        },
-        SystemEntry () {
-            name = _("Welcome & Onboarding"),
-            issues_url = "https://github.com/elementary/onboarding/issues/new/choose"
-        },
-        SystemEntry () {
-            name = _("Panel"),
-            issues_url = "https://github.com/elementary/wingpanel/issues/new/choose"
         }
     };
 


### PR DESCRIPTION
Instead of hardcoding the "Desktop Components" section, we can get them from appstream.

Todo:
- [x] https://github.com/elementary/stylesheet/pull/1206
- [x] https://github.com/elementary/greeter/pull/609
- [x] #62
- [x] https://github.com/elementary/capnet-assist/pull/83
- [x] Move applications menu to indicators since it'll be picked up by #23 later anyways

![Screenshot from 2022-05-17 10 02 05](https://user-images.githubusercontent.com/7277719/168870188-7978bcb9-fbaa-4490-af19-2e22638cc303.png)
