### PR TITLE
Application: use startup (), cleanup active window handling

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -70,7 +70,7 @@ public class Feedback.Application : Gtk.Application {
             main_window.show_all ();
         }
 
-        active_window.present_with_time (Gdk.CURRENT_TIME);
+        active_window.present ();
     }
 
     public static int main (string[] args) {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -68,7 +68,6 @@ public class Feedback.Application : Gtk.Application {
             }
 
             main_window.show_all ();
-            add_window (main_window);
         }
 
         active_window.present_with_time (Gdk.CURRENT_TIME);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -28,6 +28,14 @@ public class Feedback.Application : Gtk.Application {
         );
     }
 
+    static construct {
+        settings = new Settings ("io.elementary.feedback");
+        GLib.Intl.setlocale (LocaleCategory.ALL, "");
+        GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+        GLib.Intl.textdomain (GETTEXT_PACKAGE);
+    }
+
     protected override void startup () {
         base.startup ();
 
@@ -37,14 +45,6 @@ public class Feedback.Application : Gtk.Application {
         set_accels_for_action ("app.quit", {"<Control>q"});
 
         quit_action.activate.connect (quit);
-    }
-
-    static construct {
-        settings = new Settings ("io.elementary.feedback");
-        GLib.Intl.setlocale (LocaleCategory.ALL, "");
-        GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
-        GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
-        GLib.Intl.textdomain (GETTEXT_PACKAGE);
     }
 
     protected override void activate () {


### PR DESCRIPTION
Actions should be created on `startup ()` not every time we activate. Use `present_with_time` for showing active window on activate