### PR TITLE
DesktopEntry: modernize, remove nodisplay

### DIFF
--- a/data/feedback.desktop.in
+++ b/data/feedback.desktop.in
@@ -1,12 +1,13 @@
 [Desktop Entry]
+Version=1.0
+Type=Application
+
 Name=Feedback
 Comment=Submit and track issue reports
-GenericName=Issue Reporter
-Exec=io.elementary.feedback
-Icon=io.elementary.feedback
+Categories=Development;Utility;
 Keywords=issue;report;bug;
+
+Icon=io.elementary.feedback
+Exec=io.elementary.feedback
 Terminal=false
-Type=Application
 StartupNotify=true
-Categories=Development;
-NoDisplay=true


### PR DESCRIPTION
Fixes #1 

* Modernize to something more inline with what Metainfo Creator generates
* Remove `GenericName` that is never used
* Add `Utility` category
* Remove `NoDisplay`