### PR TITLE
Don't include apps or addons in compulsory components

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -153,7 +153,7 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
                 get_compulsory_for_desktop.begin (appstream_pool, (obj, res) => {
                     var components = get_compulsory_for_desktop.end (res);
                     components.foreach ((component) => {
-                        if (component.kind != ADDON) {
+                        if (component.kind != ADDON && !(component.id in app_entries)) {
                             var repo_row = new RepoRow (
                                 component.name,
                                 icon_from_appstream_component (component),
@@ -405,6 +405,7 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
          "io.elementary.photos",
          "io.elementary.screenshot",
          "io.elementary.shortcut-overlay",
+         "io.elementary.switchboard",
          "io.elementary.tasks",
          "io.elementary.terminal",
          "io.elementary.videos"

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -153,14 +153,16 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
                 get_compulsory_for_desktop.begin (appstream_pool, (obj, res) => {
                     var components = get_compulsory_for_desktop.end (res);
                     components.foreach ((component) => {
-                        var repo_row = new RepoRow (
-                            component.name,
-                            icon_from_appstream_component (component),
-                            Category.SYSTEM,
-                            component.get_url (AppStream.UrlKind.BUGTRACKER)
-                        );
+                        if (component.kind != ADDON) {
+                            var repo_row = new RepoRow (
+                                component.name,
+                                icon_from_appstream_component (component),
+                                Category.SYSTEM,
+                                component.get_url (AppStream.UrlKind.BUGTRACKER)
+                            );
 
-                        listbox.append (repo_row);
+                            listbox.append (repo_row);
+                        }
                     });
                 });
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -153,6 +153,7 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
                 get_compulsory_for_desktop.begin (appstream_pool, (obj, res) => {
                     var components = get_compulsory_for_desktop.end (res);
                     components.foreach ((component) => {
+                        // FIXME: This should use kind != DESKTOP_APP but some metainfo is currently inaccurate
                         if (component.kind != ADDON && !(component.id in app_entries)) {
                             var repo_row = new RepoRow (
                                 component.name,


### PR DESCRIPTION
Exclude indicators and settings panels etc from desktop components even if they are compulsory. Fixes duplicate items in #77 