### PR TITLE
MainWindow: Fix change search terms message never shown

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -97,9 +97,8 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
         };
         spinner.start ();
 
-        var placeholder = new Granite.Placeholder (
-            _("Change search terms to the name of an installed app, panel indicator, system settings page, or desktop component.")
-        ) {
+        var placeholder = new Granite.Placeholder ("") {
+            description = _("Change search terms to the name of an installed app, panel indicator, system settings page, or desktop component."),
             icon = new ThemedIcon ("edit-find-symbolic")
         };
 


### PR DESCRIPTION
### Before
The default message passed when `placeholder` declared is overwritten by `No results found for “%s”` message:

![スクリーンショット 2023-08-22 20 20 28](https://github.com/elementary/feedback/assets/26003928/eba615f4-cc35-4fe4-8e54-fa99e74ead28)

### After
I suppose this is what we meant to do here:

![スクリーンショット 2023-08-22 20 18 42](https://github.com/elementary/feedback/assets/26003928/e3b2a268-4377-4498-9632-d31ee6a48f3d)
