### PR TITLE
Replace Gtk.show_uri with Gtk.UriLauncher.launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ GitHub Issue Reporter
 ## Building, Testing, and Installation
 
 You'll need the following dependencies:
-* libappstream-dev
-* libgranite-7-dev
-* libgtk-4-dev
-* libadwaita-1-dev
+* libappstream-dev (>=0.12.10)
+* libgranite-7-dev (>=7.0.0)
+* libgtk-4-dev (>=4.10)
+* libadwaita-1-dev (>=1.0.0)
 * meson
 * valac
 

--- a/meson.build
+++ b/meson.build
@@ -40,7 +40,7 @@ executable(
         dependency('glib-2.0'),
         dependency('gobject-2.0'),
         dependency('granite-7', version: '>=7.0.0'),
-        dependency('gtk4'),
+        dependency('gtk4', version: '>= 4.10'),
         dependency('libadwaita-1', version: '>=1.0.0')
     ],
     install : true

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -356,8 +356,16 @@ public class Feedback.MainWindow : Gtk.ApplicationWindow {
     }
 
     private void launch_from_row (RepoRow row) {
-        Gtk.show_uri (null, row.url, Gdk.CURRENT_TIME);
-        close ();
+        var uri_launcher = new Gtk.UriLauncher (row.url);
+        uri_launcher.launch.begin (null, null, (obj, res) => {
+            try {
+                uri_launcher.launch.end (res);
+            } catch (Error err) {
+                warning ("Failed to launch \"%s\": %s", row.url, err.message);
+            }
+
+            close ();
+        });
     }
 
     private async GenericArray<AppStream.Component> get_compulsory_for_desktop (AppStream.Pool appstream_pool) {


### PR DESCRIPTION
It looks like the window sometimes seem to be destroyed before showing the URL, therefore nothing happens when we press the "Send Feedback…" button.

So use the Gtk.UriLauncher.launch to make sure we can destroy the window after launch finished (and also fixes the deprecation).