### PR TITLE
control: Update dependencies version limitation

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,10 +3,10 @@ Section: x11
 Priority: extra
 Maintainer: elementary, Inc. <builds@elementary.io>
 Build-Depends: debhelper (>= 10.5.1),
-               libadwaita-1-dev,
-               libappstream-dev,
-               libgranite-7-dev,
-               libgtk-4-dev,
+               libadwaita-1-dev (>= 1.0.0),
+               libappstream-dev (>= 0.12.10),
+               libgranite-7-dev (>= 7.0.0),
+               libgtk-4-dev (>= 4.10),
                meson,
                valac
 Standards-Version: 4.1.1


### PR DESCRIPTION
Goes with #111

Confirmed that building .deb succeeded locally with `debuild -us -uc`